### PR TITLE
Rename response variable from 'resp' to 'res'

### DIFF
--- a/doc/update.js
+++ b/doc/update.js
@@ -52,7 +52,7 @@ module.exports = function(RED) {
             }
 
             node.status({fill:"blue",shape:"ring",text:"updating"})
-            client.update(params).then(function (resp) {
+            client.update(params).then(function (res) {
                 node.status({fill:"green",shape:"dot",text:res.result})
                 msg.es = {
                     index: res._index,


### PR DESCRIPTION
Fixes crashing Node-RED when using the update node.